### PR TITLE
Skip download if file exists

### DIFF
--- a/Jellyfin.Plugin.YoutubeSync/YoutubeSyncTask.cs
+++ b/Jellyfin.Plugin.YoutubeSync/YoutubeSyncTask.cs
@@ -121,6 +121,18 @@ public class YoutubeSyncTask : IScheduledTask
                     string videoUrl = entry.Element(ns + "link")?.Attribute("href")?.Value;
 
                     _logger.LogInformation("Found video: {Title} - {Url}", title, videoUrl);
+
+                    // Check if a file with this title already exists in the download folder
+                    bool existing = VideoExtensions
+                        .Select(ext => Path.Combine(downloadFolder, $"{title}{ext}"))
+                        .Any(File.Exists);
+
+                    if (existing)
+                    {
+                        _logger.LogInformation("Skipping download, file already exists: {Title}", title);
+                        continue;
+                    }
+
                     var startInfo = new ProcessStartInfo
                     {
                         FileName = "yt-dlp",  // because it's already in PATH


### PR DESCRIPTION
## Summary
- pre-check for file existence before running yt-dlp

## Testing
- `dotnet build Jellyfin.Plugin.YoutubeSync.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ed6c5483c832bbcb97252dca01e7d