### PR TITLE
Update cleanup logic

### DIFF
--- a/Jellyfin.Plugin.YoutubeSync/YoutubeSyncTask.cs
+++ b/Jellyfin.Plugin.YoutubeSync/YoutubeSyncTask.cs
@@ -184,7 +184,22 @@ public class YoutubeSyncTask : IScheduledTask
                             try
                             {
                                 _logger.LogInformation("Removing watched episode {File}", file.Name);
-                                file.Delete();
+
+                                var baseName = Path.GetFileNameWithoutExtension(file.Name);
+                                var dir = file.DirectoryName ?? string.Empty;
+
+                                foreach (var associatedPath in Directory.EnumerateFiles(dir, baseName + ".*"))
+                                {
+                                    try
+                                    {
+                                        File.Delete(associatedPath);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        _logger.LogWarning(ex, "Failed to delete associated file {File}", associatedPath);
+                                    }
+                                }
+
                                 remaining--;
                             }
                             catch (Exception ex)


### PR DESCRIPTION
## Summary
- delete any files with the same base name when removing watched episodes

## Testing
- `dotnet build Jellyfin.Plugin.YoutubeSync.sln` *(fails: command not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684ed94ae338832ba5b3fd8c4c63076d