### PR TITLE
Implement per-channel progress

### DIFF
--- a/Jellyfin.Plugin.YoutubeSync/YoutubeSyncTask.cs
+++ b/Jellyfin.Plugin.YoutubeSync/YoutubeSyncTask.cs
@@ -74,8 +74,10 @@ public class YoutubeSyncTask : IScheduledTask
         bool autoDeletePlayed = config.AutoDeletePlayed;
 
         string[] channels = youtubeUrl.Split(',');
-        foreach (string channelId in channels)
+        var channelCount = channels.Length;
+        for (int i = 0; i < channelCount; i++)
         {
+            var channelId = channels[i];
             _logger.LogInformation("Syncing from {YoutubeUrl}, Episodes: {Episodes}, AutoDelete: {AutoDelete}", channelId, episodes, autoDeletePlayed);
 
             _logger.LogInformation("Saving to: {VideoLocation}, Episodes: {Episodes}, AutoDelete: {AutoDeletePlayed}", videoLocation, episodes, autoDeletePlayed);
@@ -93,7 +95,8 @@ public class YoutubeSyncTask : IScheduledTask
                 var ns = doc.Root.GetDefaultNamespace();
                 string channelName = doc.Root.Element(ns + "title").Value;
 
-                progress.Report(10);
+                // Report progress based on the current channel index.
+                progress.Report(100.0 * i / channelCount);
 
                 // Create folder for the title
 
@@ -211,7 +214,6 @@ public class YoutubeSyncTask : IScheduledTask
                 }
 
                 _logger.LogInformation("YouTube Sync Task completed successfully.");
-                progress.Report(100);
             }
             catch (Exception ex)
             {

--- a/Jellyfin.Plugin.YoutubeSync/YoutubeSyncTask.cs
+++ b/Jellyfin.Plugin.YoutubeSync/YoutubeSyncTask.cs
@@ -95,8 +95,6 @@ public class YoutubeSyncTask : IScheduledTask
                 var ns = doc.Root.GetDefaultNamespace();
                 string channelName = doc.Root.Element(ns + "title").Value;
 
-                // Report progress based on the current channel index.
-                progress.Report(100.0 * i / channelCount);
 
                 // Create folder for the title
 
@@ -220,6 +218,8 @@ public class YoutubeSyncTask : IScheduledTask
                 _logger.LogError(ex, "YouTube Sync Task failed.");
                 throw;
             }
+
+            progress.Report(100.0 * (i + 1) / channelCount);
         }
     }
 


### PR DESCRIPTION
## Summary
- show progress based on the number of configured channels using the loop index

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee1a01618832b80166ba353bd808f